### PR TITLE
Add Fraterium coin to Venom venomswap community token list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venomswap/community-token-list",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "description": "◦ The Venomswap default token list",
   "main": "build/venomswap-community.tokenlist.json",
   "scripts": {

--- a/src/tokens/harmony-mainnet.json
+++ b/src/tokens/harmony-mainnet.json
@@ -125,6 +125,6 @@
     "symbol": "FRATE",
     "name": "Fraterium",
     "decimals": 18,
-    "logoURI": "https://drive.google.com/file/d/1EB9tdbsdTVadc_SmiMdtTsuAshkwtrjj/view?usp=sharing"
+    "logoURI": "https://drive.google.com/file/d/1ectTV1j9LlFqOBVpBH6No1yFGUFY2Dog/view?usp=sharing"
   }
 ]

--- a/src/tokens/harmony-mainnet.json
+++ b/src/tokens/harmony-mainnet.json
@@ -1,98 +1,122 @@
 [
   {
-    "chainId": 1666600000,
-    "address": "0x85a1DD919cd605aa2EAD4b01ff1190504BcAb609",
-    "symbol": "EUSK",
-    "name": "Mintbes Token",
-    "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/EUSK.png"
+    "chainId":1666600000,
+    "address":"0x85a1DD919cd605aa2EAD4b01ff1190504BcAb609",
+    "symbol":"EUSK",
+    "name":"Mintbes Token",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/EUSK.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x7d0546dBb1Dca8108d99Aa389A8e9Ce0C40B2370",
+    "symbol":"LMA",
+    "name":"LMA-Art-Gallery",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/LMA.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x0a703601f8F641D4578A3d91C443e75F5a47a1A3",
+    "symbol":"CTS",
+    "name":"Clays Tipping Service",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/CTS.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x3Ec248eD4B69142A40FB2F2b9d990125a830A598",
+    "symbol":"NFT",
+    "name":"CryptoBunny",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/NFT.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x9017527236D84F96CF9AE6107629eFDa84B5c964",
+    "symbol":"MUSQ",
+    "name":"MUSIQ",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/MUSQ.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x7531905C4C80b602CFf46Badc1671FbAD496f043",
+    "symbol":"MCONE",
+    "name":"McOne Coin",
+    "decimals":9,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/MCONE.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x5415B30fc46317ef494fa96d755350437aE15ac9",
+    "symbol":"LFGT",
+    "name":"Let's Fucking Go Token",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/LFGT.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x495500b582ab72AD47Eb2D301469CE799BDdF9e4",
+    "symbol":"BOOM",
+    "name":"Boomers",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/BOOM.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x8D4F19bec883Ba20F4f295706C53F760Cd0BC2B0",
+    "symbol":"MOONI",
+    "name":"Moonity",
+    "decimals":9,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/MOONI.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0xE59AA7f9e91B4Cc6C25D3542CEcb851e0316138c",
+    "symbol":"YIN",
+    "name":"Yin",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/YIN.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x340042552D19211795dbe55d84FA2E63bc49B890",
+    "symbol":"YANG",
+    "name":"Yang",
+    "decimals":18,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/YANG.png"
+  },
+  {
+    "chainId":1666600000,
+    "address":"0x3E018675c0Ef63eB361b9EF4bfEa3A3294C74C7b",
+    "symbol":"KURO",
+    "name":"Kuro Shiba",
+    "decimals":9,
+    "logoURI":"https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/KURO.png"
   },
   {
     "chainId": 1666600000,
-    "address": "0x7d0546dBb1Dca8108d99Aa389A8e9Ce0C40B2370",
-    "symbol": "LMA",
-    "name": "LMA-Art-Gallery",
+    "address": "0xFd2a8F8cF7CFFeA4a613F1DFf39b22881D4a1f92",
+    "symbol": "1ROT",
+    "name": "RottenToken",
     "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/LMA.png"
+    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/1ROT.png"
   },
   {
     "chainId": 1666600000,
-    "address": "0x0a703601f8F641D4578A3d91C443e75F5a47a1A3",
-    "symbol": "CTS",
-    "name": "Clays Tipping Service",
+    "address": "0xBfD4F1699b83eDBa1106B6E224b7aC599A40be1F",
+    "symbol": "1MAGGOT",
+    "name": "MaggotToken",
     "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/CTS.png"
+    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/1MAGGOT.png"
   },
   {
     "chainId": 1666600000,
-    "address": "0x3Ec248eD4B69142A40FB2F2b9d990125a830A598",
-    "symbol": "NFT",
-    "name": "CryptoBunny",
+    "address": "0x01546F85fBB5e116b4a43fC3D1B1213D82aCDA95",
+    "symbol": "1MIL",
+    "name": "ONEMILLION",
     "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/NFT.png"
-  },
-  {
-    "chainId": 1666600000,
-    "address": "0x9017527236D84F96CF9AE6107629eFDa84B5c964",
-    "symbol": "MUSQ",
-    "name": "MUSIQ",
-    "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/MUSQ.png"
-  },
-  {
-    "chainId": 1666600000,
-    "address": "0x7531905C4C80b602CFf46Badc1671FbAD496f043",
-    "symbol": "MCONE",
-    "name": "McOne Coin",
-    "decimals": 9,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/MCONE.png"
-  },
-  {
-    "chainId": 1666600000,
-    "address": "0x5415B30fc46317ef494fa96d755350437aE15ac9",
-    "symbol": "LFGT",
-    "name": "Let's Fucking Go Token",
-    "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/LFGT.png"
-  },
-  {
-    "chainId": 1666600000,
-    "address": "0x495500b582ab72AD47Eb2D301469CE799BDdF9e4",
-    "symbol": "BOOM",
-    "name": "Boomers",
-    "decimals": 18,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/BOOM.png"
-  },
-  {
-    "chainId": 1666600000,
-    "address": "0x8D4F19bec883Ba20F4f295706C53F760Cd0BC2B0",
-    "symbol": "MOONI",
-    "name": "Moonity",
-    "decimals": 9,
-    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/MOONI.png"
-  }
-   {
-    "chainId": 1666600000,
-    "address": "0xE59AA7f9e91B4Cc6C25D3542CEcb851e0316138c",
-    "symbol": "YIN",
-    "name": "Yin",
-    "decimals": 18,
-    "logoURI": "https://github.com/freyala/Community-Tokens/blob/main/Yin%20(1).png?raw=true"
-  }
- {
-    "chainId": 1666600000,
-    "address": "0x340042552D19211795dbe55d84FA2E63bc49B890",
-    "symbol": "YANG",
-    "name": "Yang",
-    "decimals": 18,
-    "logoURI": "https://github.com/freyala/Community-Tokens/blob/main/Yang%20(1).png?raw=true"
-  }
- {
-    "chainId": 1666600000,
-    "address": "0x3E018675c0Ef63eB361b9EF4bfEa3A3294C74C7b",
-    "symbol": "KURO",
-    "name": "Kuro Shiba",
-    "decimals": 9,
-    "logoURI": "https://github.com/freyala/Community-Tokens/blob/main/KURO_token_small.png?raw=true"
+    "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/1MIL.png"
   }
 ]


### PR DESCRIPTION
Fraterium token is created to serve as a unit of value accounting within the framework of the relationship in the Frateria people's association and a tool for conducting mutual settlements between united citizens, with the consent of the parties involved in these operations.
It is a HardCap coin with only 3391 coins created.
Frateria itself is planning to serve as a didactic center to entities willing to benefit from the blockchain and DeFi technologies.