### PR TITLE
Update to add Yogurt ($YOG) to the token list

### DIFF
--- a/src/tokens/harmony-mainnet.json
+++ b/src/tokens/harmony-mainnet.json
@@ -118,5 +118,13 @@
     "name": "ONEMILLION",
     "decimals": 18,
     "logoURI": "https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/1MIL.png"
+  },
+  {
+    "chainId": 1666600000,
+    "address": "0x8948985338e836f82435efc944fe5131c734c18e",
+    "symbol": "YOG",
+    "name": "Yogurt",
+    "decimals": 18,
+    "logoURI": "https://pasteboard.co/K8pCBLG.png"
   }
 ]


### PR DESCRIPTION
Yogurt is not yet another useless HRC-20 token on Harmony. But with a value, which gets defined by memes of yogurt and other milk based food.

It would be a huge step for the non-animal oriented meme token, to get listed in the official community token list of VenomDAO. Thanks!